### PR TITLE
Fix: 페이지 라우팅 버그 수정 및 busStopId에 따른 동적 API 호출

### DIFF
--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -10,22 +10,26 @@ import FindBusInput from './components/FindBusInput';
 import * as S from './styles';
 
 const SIDE_BAR_MAP = {
-  [CATEGORY.HOME]: BusStopsAround,
-  [CATEGORY.FAVORITE]: Favorites,
+  [CATEGORY.HOME]: () => <BusStopsAround />,
+  [CATEGORY.FAVORITE]: () => <Favorites />,
   [CATEGORY.TIMETABLE]: () => <div>시간표</div>,
   [CATEGORY.MYINFO]: () => <div>내 정보</div>,
-  [CATEGORY.BUSDETAILINFO]: BusDetailInfo,
-  [CATEGORY.BUSSTOPINFO]: BusStopInfo,
+  [CATEGORY.BUSDETAILINFO]: () => <BusDetailInfo />,
+  [CATEGORY.BUSSTOPINFO]: () => <BusStopInfo />,
 };
 
 function SideBar() {
   const [category] = useRecoilState(navigationBarState);
+
+  const Component = SIDE_BAR_MAP[category];
+
   return (
     <S.Wrapper>
       {category !== CATEGORY.FAVORITE && <FindBusInput />}
-      <S.BusStopItemWrapper>{SIDE_BAR_MAP[category]()}</S.BusStopItemWrapper>
+      <S.BusStopItemWrapper>
+        {Component ? <Component /> : <div>카테고리 없음</div>}
+      </S.BusStopItemWrapper>
     </S.Wrapper>
   );
 }
-
 export default SideBar;

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -15,19 +15,27 @@ const SIDE_BAR_MAP = {
   [CATEGORY.TIMETABLE]: () => <div>시간표</div>,
   [CATEGORY.MYINFO]: () => <div>내 정보</div>,
   [CATEGORY.BUSDETAILINFO]: () => <BusDetailInfo />,
-  [CATEGORY.BUSSTOPINFO]: () => <BusStopInfo />,
+  [CATEGORY.BUSSTOPINFO]: (busStopId) => <BusStopInfo busStopId={busStopId.busStopId} />,
 };
 
 function SideBar() {
   const [category] = useRecoilState(navigationBarState);
 
   const Component = SIDE_BAR_MAP[category];
-
+  const busStopId = new URLSearchParams(window.location.search).get('busStopId');
   return (
     <S.Wrapper>
       {category !== CATEGORY.FAVORITE && <FindBusInput />}
       <S.BusStopItemWrapper>
-        {Component ? <Component /> : <div>카테고리 없음</div>}
+        {Component ? (
+          category === CATEGORY.BUSSTOPINFO ? (
+            <Component busStopId={busStopId} />
+          ) : (
+            <Component />
+          )
+        ) : (
+          <div>카테고리 없음</div>
+        )}
       </S.BusStopItemWrapper>
     </S.Wrapper>
   );

--- a/src/constants/route.js
+++ b/src/constants/route.js
@@ -3,6 +3,6 @@ export const ROUTE = {
   SIGNUP: '/signup',
   LOGIN: '/login',
   FAVORITE: '/favorites',
-  BUSFIND: '/search/bus/:busNumber',
-  BUSSTOP: '/search/station/:busStop',
+  BUSFIND: '/search/bus/:busNumber', // 버스 번호로 검색
+  BUSSTOP: '/search/station/:busStop', // 버스정류장 검색
 };

--- a/src/pages/busStopFindPage/components/index.jsx
+++ b/src/pages/busStopFindPage/components/index.jsx
@@ -1,14 +1,16 @@
+import { navigationBarState } from '@atoms/navigationBarState';
 import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 import BusInfoItem from './BusInfoItem';
 import BusStopHeader from './BusStopHeader';
 import { getLowArrInfoByStId } from '../api';
 
-function BusStopInfo() {
+function BusStopInfo({ busStopId }) {
   const [busInfoList, setBusInfoList] = useState([]);
   const fetchBusInfo = async () => {
     try {
-      const busData = await getLowArrInfoByStId('121000009'); // 예시 stId 사용
+      const busData = await getLowArrInfoByStId(busStopId); // 예시 stId 사용
       setBusInfoList(busData);
     } catch (error) {
       console.error('Error fetching bus info:', error);
@@ -22,6 +24,7 @@ function BusStopInfo() {
   useEffect(() => {
     fetchBusInfo();
   }, []);
+
   return (
     <div>
       <BusStopHeader />

--- a/src/pages/mainpage/components/BusStopItem.jsx
+++ b/src/pages/mainpage/components/BusStopItem.jsx
@@ -1,10 +1,21 @@
 import BlueBusIcon from '@assets/svg/BlueBusIcon.svg?react';
 import FavoriteIcon from '@assets/svg/FavoriteIcon.svg?react';
-import { STYLE } from '@constants/const';
+import { navigationBarState } from '@atoms/navigationBarState';
+import { CATEGORY, STYLE } from '@constants/const';
+import { ROUTE } from '@constants/route';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
-function BusStopItem({ busStopName, busStopNumber, busDirection }) {
+function BusStopItem({ busStopName, busStopNumber, busDirection, busStopId }) {
+  const navigate = useNavigate();
+  const [, setCategory] = useRecoilState(navigationBarState);
+  const navToBusStop = (busStopId) => {
+    const stopRoute = ROUTE.BUSSTOP.replace(':busStop', busStopName); // 정류장 검색
+    setCategory(CATEGORY.BUSSTOPINFO);
+    navigate(stopRoute + '?busStopId=' + busStopId);
+  };
   return (
-    <Wrapper>
+    <Wrapper onClick={() => navToBusStop(busStopId)}>
       <BusItemWrapper>
         <NameWrapper>
           <BlueBusIcon width={30} height={30} />
@@ -59,7 +70,6 @@ const BusStopName = styled.div`
   font-size: 18px;
   font-style: normal;
   font-weight: 600;
-  line-height: normal;
 `;
 
 const BusStopNumber = styled.div`

--- a/src/pages/mainpage/components/index.jsx
+++ b/src/pages/mainpage/components/index.jsx
@@ -12,6 +12,7 @@ function BusStopsAround() {
           busStopName={busStop.stopsNm}
           busStopNumber={busStop.stopsNo}
           busDirection={busStop.direction}
+          busStopId={busStop.nodeId}
         />
       ))}
     </div>

--- a/src/pages/mainpage/index.jsx
+++ b/src/pages/mainpage/index.jsx
@@ -1,12 +1,21 @@
+import { navigationBarState } from '@atoms/navigationBarState';
 import NavigationBar from '@components/NavigationBar';
 import SideBar from '@components/SideBar';
+import { CATEGORY } from '@constants/const';
+import { useEffect } from 'react';
 import { NavermapsProvider } from 'react-naver-maps';
+import { useRecoilState } from 'recoil';
 
 import NaverMapContainer from './NaverMapContainer';
 import * as S from './styles';
 function Mainpage() {
   const naverMapClientId = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
-
+  const [, setCategory] = useRecoilState(navigationBarState);
+  useEffect(() => {
+    if (location.pathname === '/') {
+      setCategory(CATEGORY.HOME); // URL이 "/"일 때 category를 HOME으로 변경
+    }
+  }, [location.pathname, setCategory]);
   return (
     <>
       <S.SideWrapper>


### PR DESCRIPTION
close #29 

## 구현 사항
- 브라우저 뒤로가기 시 메인페이지 (busStopAround)로 카테고리가 설정되도록 구현하였습니다.

## 변동 사항
- busStopId에 따라 동적으로 API 호출 할 수 있도록 변경하였습니다
- 사이드바 컴포넌트 렌더링 방식을 함수로 변경하였습니다.
