### PR TITLE
Feat: 버스정류장 페이지, 즐겨찾기 페이지 내에서 버스 클릭시 버스 정보 페이지로 라우팅 구현

### DIFF
--- a/src/components/NavigationBar/index.jsx
+++ b/src/components/NavigationBar/index.jsx
@@ -3,7 +3,7 @@ import FilledStarIcon from '@assets/svg/filledStarIcon.svg?react';
 import HomeIcon from '@assets/svg/homeIcon.svg?react';
 import TimeIcon from '@assets/svg/timeIcon.svg?react';
 import UserIcon from '@assets/svg/userIcon.svg?react';
-import { navigationBarState } from '@atoms/navigationBarState';
+import { navigationBarState } from '@atoms/NavigationBarState';
 import { CATEGORY } from '@constants/const';
 import { useRecoilState } from 'recoil';
 

--- a/src/pages/FavoritesPage/components/FavoriteItem.jsx
+++ b/src/pages/FavoritesPage/components/FavoriteItem.jsx
@@ -12,7 +12,9 @@ function FavoriteItem({ arrmsg1, stNm, exps1, exps2, rtNm, stId, busRouteId, rou
   const [left2, setLeft2] = useState(exps2);
   const modalRef = useRef();
   const iconWrapperRef = useRef();
-
+  if (rtNm === '400') {
+    console.log(arrmsg1);
+  }
   const handleClickOutside = (event) => {
     if (
       modalRef.current &&
@@ -76,7 +78,7 @@ function FavoriteItem({ arrmsg1, stNm, exps1, exps2, rtNm, stId, busRouteId, rou
               <BusNum>{rtNm}</BusNum>
             </BusInfo>
             <ArrivalDetails>
-              {arrmsg1 === '운행종료' ? (
+              {(arrmsg1 === '운행종료') | (arrmsg1 === '출발대기') ? (
                 <ArrivalMessage>{arrmsg1}</ArrivalMessage>
               ) : (
                 <ArrivalDetails>

--- a/src/pages/FavoritesPage/components/FavoriteItem.jsx
+++ b/src/pages/FavoritesPage/components/FavoriteItem.jsx
@@ -9,17 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
-function FavoriteItem({
-  arrmsg1,
-  stNm,
-  exps1,
-  exps2,
-  rtNm,
-  stId,
-  busRouteId,
-  routeType,
-  handleClick,
-}) {
+function FavoriteItem({ arrmsg1, arrmsg2, stNm, exps1, exps2, rtNm, stId, busRouteId, routeType }) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { direction } = useGetDirection(busRouteId);
   const [left1, setLeft1] = useState(exps1);
@@ -101,10 +91,12 @@ function FavoriteItem({
               {(arrmsg1 === '운행종료') | (arrmsg1 === '출발대기') ? (
                 <ArrivalMessage>{arrmsg1}</ArrivalMessage>
               ) : (
-                <ArrivalDetails>
-                  <ArrivalMessage>{formatTime(left1)}</ArrivalMessage>
-                  <ArrivalMessage>{formatTime(left2)}</ArrivalMessage>
-                </ArrivalDetails>
+                <ArrivalMessage>{formatTime(left1)}</ArrivalMessage>
+              )}
+              {(arrmsg2 === '운행종료') | (arrmsg2 === '출발대기') ? (
+                <ArrivalMessage>{arrmsg2}</ArrivalMessage>
+              ) : (
+                <ArrivalMessage>{formatTime(left2)}</ArrivalMessage>
               )}
             </ArrivalDetails>
           </MoreInfos>

--- a/src/pages/FavoritesPage/components/FavoriteItem.jsx
+++ b/src/pages/FavoritesPage/components/FavoriteItem.jsx
@@ -1,20 +1,32 @@
 import ThreeDotIcon from '@assets/svg/ThreeDotIcon.svg?react';
 import TrashIcon from '@assets/svg/TrashIcon.svg?react';
-import { ROUTETYPECOLORS, ROUTETYPETAG } from '@constants/const';
+import { navigationBarState } from '@atoms/NavigationBarState';
+import { CATEGORY, ROUTETYPECOLORS, ROUTETYPETAG } from '@constants/const';
+import { ROUTE } from '@constants/route';
 import useGetDirection from '@hooks/useGetDirection';
 import { formatTime } from '@pages/busStopPage/utils/formatTime';
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
-function FavoriteItem({ arrmsg1, stNm, exps1, exps2, rtNm, stId, busRouteId, routeType }) {
+function FavoriteItem({
+  arrmsg1,
+  stNm,
+  exps1,
+  exps2,
+  rtNm,
+  stId,
+  busRouteId,
+  routeType,
+  handleClick,
+}) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { direction } = useGetDirection(busRouteId);
   const [left1, setLeft1] = useState(exps1);
   const [left2, setLeft2] = useState(exps2);
   const modalRef = useRef();
   const iconWrapperRef = useRef();
-  if (rtNm === '400') {
-    console.log(arrmsg1);
-  }
+
   const handleClickOutside = (event) => {
     if (
       modalRef.current &&
@@ -48,9 +60,17 @@ function FavoriteItem({ arrmsg1, stNm, exps1, exps2, rtNm, stId, busRouteId, rou
   const toggleDeleteModal = () => {
     setIsDeleteModalOpen((prev) => !prev);
   };
+
+  const [, setCategory] = useRecoilState(navigationBarState);
+  const navigate = useNavigate();
+  const navigateToBusDetail = (rtNm) => {
+    const url = ROUTE.BUSFIND.replace(':busNumber', rtNm);
+    navigate(url);
+    setCategory(CATEGORY.BUSDETAILINFO);
+  };
   return (
     <>
-      <Wrapper>
+      <Wrapper onClick={() => navigateToBusDetail(rtNm)}>
         <ItemWrapper>
           {isDeleteModalOpen && (
             <DeleteModal ref={modalRef}>

--- a/src/pages/FavoritesPage/components/index.jsx
+++ b/src/pages/FavoritesPage/components/index.jsx
@@ -1,10 +1,5 @@
-import { navigationBarState } from '@atoms/NavigationBarState';
-import { CATEGORY } from '@constants/const';
-import { ROUTE } from '@constants/route';
 import * as busApi from '@pages/busStopPage/api';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import FavoriteItem from './FavoriteItem';
@@ -15,7 +10,6 @@ function Favorites() {
   const [reloadTime, setReloadTime] = useState(new Date());
   const [favBusCnt, setFavBusCnt] = useState(0);
   const [busInfoList, setBusInfoList] = useState([]);
-  const navigate = useNavigate();
   const refreshFavoritBusInfo = async () => {
     try {
       setBusInfoList([]);

--- a/src/pages/FavoritesPage/components/index.jsx
+++ b/src/pages/FavoritesPage/components/index.jsx
@@ -1,5 +1,10 @@
+import { navigationBarState } from '@atoms/NavigationBarState';
+import { CATEGORY } from '@constants/const';
+import { ROUTE } from '@constants/route';
 import * as busApi from '@pages/busStopPage/api';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import FavoriteItem from './FavoriteItem';
@@ -10,7 +15,7 @@ function Favorites() {
   const [reloadTime, setReloadTime] = useState(new Date());
   const [favBusCnt, setFavBusCnt] = useState(0);
   const [busInfoList, setBusInfoList] = useState([]);
-
+  const navigate = useNavigate();
   const refreshFavoritBusInfo = async () => {
     try {
       setBusInfoList([]);

--- a/src/pages/busStopPage/components/BusInfoItem.jsx
+++ b/src/pages/busStopPage/components/BusInfoItem.jsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import { formatTime } from '../utils/formatTime';
 
-function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2 }) {
+function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2, arrmsg2 }) {
   const { direction } = useGetDirection(busRouteId);
   const [left1, setLeft1] = useState(exps1);
   const [left2, setLeft2] = useState(exps2);
@@ -118,15 +118,15 @@ function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2 }) {
             )}
           </RouteDetails>
           <ArrivalDetails>
-            {arrmsg1 === '운행종료' ? (
-              <ArrivalMessage>{arrmsg1}</ArrivalMessage>
-            ) : arrmsg1 === '출발대기' ? (
+            {(arrmsg1 === '운행종료') | (arrmsg1 === '출발대기') ? (
               <ArrivalMessage>{arrmsg1}</ArrivalMessage>
             ) : (
-              <ArrivalDetails>
-                <ArrivalMessage>{formatTime(left1)}</ArrivalMessage>
-                <ArrivalMessage>{formatTime(left2)}</ArrivalMessage>
-              </ArrivalDetails>
+              <ArrivalMessage>{formatTime(left1)}</ArrivalMessage>
+            )}
+            {(arrmsg2 === '운행종료') | (arrmsg2 === '출발대기') ? (
+              <ArrivalMessage>{arrmsg2}</ArrivalMessage>
+            ) : (
+              <ArrivalMessage>{formatTime(left2)}</ArrivalMessage>
             )}
           </ArrivalDetails>
         </BusInfo>

--- a/src/pages/busStopPage/components/BusInfoItem.jsx
+++ b/src/pages/busStopPage/components/BusInfoItem.jsx
@@ -2,10 +2,14 @@ import BlueBusIcon from '@assets/svg/BlueBusIcon.svg?react';
 import BothArrow from '@assets/svg/BothArrow.svg?react';
 import FavoriteIcon from '@assets/svg/FavoriteIcon.svg?react';
 import FilledStarIcon from '@assets/svg/FilledStarIcon.svg?react';
+import { navigationBarState } from '@atoms/NavigationBarState';
+import { CATEGORY } from '@constants/const';
+import { ROUTE } from '@constants/route';
 import useGetDirection from '@hooks/useGetDirection';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { formatTime } from '../utils/formatTime';
@@ -18,6 +22,7 @@ function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2, arrmsg2 }) {
   const [isFavorite, setIsFavorite] = useState(false);
   const { busStopName } = useParams();
   const busStopId = new URLSearchParams(window.location.search).get('busStopId');
+
   useEffect(() => {
     const interval = setInterval(() => {
       setLeft1((prev) => (prev > 0 ? prev - 1 : 0));
@@ -89,8 +94,16 @@ function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2, arrmsg2 }) {
       throw new Error(e);
     }
   };
+
+  const [, setCategory] = useRecoilState(navigationBarState);
+  const navigate = useNavigate();
+  const navigateToBusDetail = (rtNm) => {
+    const url = ROUTE.BUSFIND.replace(':busNumber', rtNm);
+    navigate(url);
+    setCategory(CATEGORY.BUSDETAILINFO);
+  };
   return (
-    <Wrapper>
+    <Wrapper onClick={() => navigateToBusDetail(rtNm)}>
       <BusInfoWrapper>
         <IconWrapper>
           <BlueBusIcon style={{ width: '24px', height: '24px' }} />


### PR DESCRIPTION
close #46 

## 구현 사항
버스 정류장 페이지, 즐겨찾기 페이지 내에서 버스 클릭시 버스 정보 페이지로 라우팅 구현

## 변동 사항
- 버스 남은 시각을 보여주는 출발대기, 운행종료를 보여주는 로직을 변경하였습니다.


## 스크린샷

![JG-41:feat](https://github.com/user-attachments/assets/da2291bd-e537-49eb-a869-f89e38746f72)

