### PR TITLE
JG-47 Fix: 즐겨찾기 페이지 내에서 즐겨찾기 배열이 중복으로 들어가는 버그 해결

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "d8cac829",
+  "configHash": "2f2f56fd",
+  "lockfileHash": "e3b0c442",
+  "browserHash": "14d119d8",
+  "optimized": {},
+  "chunks": {}
+}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/apis/favorite.js
+++ b/src/apis/favorite.js
@@ -8,7 +8,6 @@ export const getLowArrInfoByStId = async (stId) => {
         stId: stId,
       },
     });
-
     const data = res.data.msgBody.itemList;
     return data;
   } catch (e) {

--- a/src/pages/FavoritesPage/components/FavoriteItem.jsx
+++ b/src/pages/FavoritesPage/components/FavoriteItem.jsx
@@ -1,6 +1,6 @@
 import ThreeDotIcon from '@assets/svg/ThreeDotIcon.svg?react';
 import TrashIcon from '@assets/svg/TrashIcon.svg?react';
-import { navigationBarState } from '@atoms/NavigationBarState';
+import { navigationBarState } from '@atoms/navigationBarState';
 import { CATEGORY, ROUTETYPECOLORS, ROUTETYPETAG } from '@constants/const';
 import { ROUTE } from '@constants/route';
 import useGetDirection from '@hooks/useGetDirection';
@@ -22,6 +22,7 @@ function FavoriteItem({
   busRouteId,
   routeType,
   setIsCancelFavorite,
+  refreshFavoritBusInfo,
 }) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { direction } = useGetDirection(busRouteId);
@@ -49,6 +50,7 @@ function FavoriteItem({
 
     return () => clearInterval(interval);
   }, []);
+
   useEffect(() => {
     if (isDeleteModalOpen) {
       document.addEventListener('mousedown', handleClickOutside);
@@ -87,6 +89,7 @@ function FavoriteItem({
         alert('즐겨찾기에서 삭제되었습니다.');
         setIsDeleteModalOpen(false);
         setIsCancelFavorite(true);
+        refreshFavoritBusInfo();
       }
     } catch (e) {
       throw new Error(e);

--- a/src/pages/FavoritesPage/components/index.jsx
+++ b/src/pages/FavoritesPage/components/index.jsx
@@ -9,25 +9,18 @@ import Header from './Header';
 function Favorites() {
   const [isLoading, setIsLoading] = useState(true);
   const [reloadTime, setReloadTime] = useState(new Date());
-  const [favBusCnt, setFavBusCnt] = useState(0);
   const [busInfoList, setBusInfoList] = useState([]);
   const [isCancelFavorite, setIsCancelFavorite] = useState(false);
 
-  useEffect(() => {
-    refreshFavoritBusInfo();
-  }, [isCancelFavorite]);
-
   const refreshFavoritBusInfo = async () => {
     try {
-      setBusInfoList([]);
       setIsLoading(true);
       const data = await busApi.getAllFavorites();
-      setFavBusCnt(data.length);
+      setBusInfoList([]);
       await Promise.all(
         data.map(async ({ busStopId, routeId }) => {
           const busData = await busApi.getLowArrInfoByStId(busStopId);
           const newData = busData.filter((bus) => bus.busRouteId === routeId);
-          // setBusInfoList([]);
           setBusInfoList((prev) => [...prev, ...newData]);
         }),
       );
@@ -38,13 +31,10 @@ function Favorites() {
     }
   };
 
-  useEffect(() => {
-    console.log(isLoading);
-  }, [isLoading]);
 
   useEffect(() => {
-    setFavBusCnt(0);
     refreshFavoritBusInfo();
+    setBusInfoList([]);
 
     const intervalId = setInterval(() => {
       setReloadTime(new Date());
@@ -53,9 +43,7 @@ function Favorites() {
     return () => clearInterval(intervalId);
   }, []);
 
-  useEffect(() => {
-    console.log('busInfoList', busInfoList);
-  }, [busInfoList]);
+  
 
   return (
     <Wrapper>
@@ -68,7 +56,12 @@ function Favorites() {
         ) : (
           <ItemWrapper>
             {busInfoList.map((busInfo, index) => (
-              <FavoriteItem key={index} {...busInfo} setIsCancelFavorite={setIsCancelFavorite} />
+              <FavoriteItem
+                key={index}
+                {...busInfo}
+                setIsCancelFavorite={setIsCancelFavorite}
+                refreshFavoritBusInfo={refreshFavoritBusInfo}
+              />
             ))}
           </ItemWrapper>
         )}


### PR DESCRIPTION
close #57 

## 구현 사항
- Favorites 컴포넌트에서 삭제을 클릭 할 경우 refreshFavoriteBusInfo가 호출되도록 useEffect 훅을 작성하였습니다.
- 그러나 컴포넌트가 마운트 될 경우에도 해당 훅이 동작하기 때문에 중복으로 호출되었던 것이었습니다

## 변동 사항
- refreshFavoriteBusInfo를 useEffect를 사용해 호출하는 것이 아닌, cancelFavorite이 호출되고나서 refreshFavoriteBusInfo를 호출하도록 변경하여 해결할 수 있었습니다.

