### PR TITLE
JG-51 Fix: 즐겨찾기 추가/삭제 클릭 이벤트 버블링 중단

### DIFF
--- a/src/pages/busStopPage/components/BusInfoItem.jsx
+++ b/src/pages/busStopPage/components/BusInfoItem.jsx
@@ -33,7 +33,8 @@ function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2, arrmsg2 }) {
     return () => clearInterval(interval);
   }, []);
 
-  const handleAddFavorite = async () => {
+  const handleAddFavorite = async (e) => {
+    e.stopPropagation();
     try {
       const res = await axios.post(
         'http://localhost:8080/favorites/add',
@@ -76,7 +77,8 @@ function BusInfoItem({ arrmsg1, busRouteId, rtNm, exps1, exps2, arrmsg2 }) {
     handleGetFavorites();
   }, []);
 
-  const handleCancelFavorite = async () => {
+  const handleCancelFavorite = async (e) => {
+    e.stopPropagation();
     try {
       const res = await axios.delete('http://localhost:8080/favorites/delete', {
         headers: {


### PR DESCRIPTION
close #65 

## 원인
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/8c5347b0-bcbe-4815-a8b3-b550129bdc15">

- 즐겨찾기 추가/삭제를 위해 FilledStarIcon 아이콘에 클릭 이벤트를 달아주었습니다. 
- 최 상단 Wrapper에도 클릭 이벤트를 달아주었기에, 즐겨찾기 추가/삭제 클릭 이벤트가 실행되고 해당 클릭 이벤트가 부모 요소로 버블링 되어 Wrapper의 클릭 이벤트 또한 실행되었습니다.
- 이를 해결하기 위해 즐겨찾기 추가/삭제 함수에 e.stopPropagtion() 함수를 실행하도록 수정하니 버그가 해결되었습니다, 

